### PR TITLE
Delay starting druid services to give room for mysql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,10 @@ ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 # Add Yarn conf
 ADD yarn-conf /etc/hadoop/conf/
 
+# Druid overlord may be stuck in a bad state if mysql is not ready.
+# We'll delay the start of all druid services using this script.
+ADD delay-start.sh /usr/local/bin/
+
 # Expose ports:
 # - 8081: HTTP (coordinator)
 # - 8082: HTTP (broker)

--- a/delay-start.sh
+++ b/delay-start.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+sleep $1
+shift
+exec "$@"

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -14,7 +14,7 @@ priority=0
 
 [program:druid-coordinator]
 user=druid
-command=java
+command=delay-start.sh 10 java
   -server
   -Xmx1g
   -Duser.timezone=UTC
@@ -34,7 +34,7 @@ priority=100
 
 [program:druid-indexing-service]
 user=druid
-command=java
+command=delay-start.sh 10 java
   -server
   -Xmx256m
   -Duser.timezone=UTC
@@ -59,7 +59,7 @@ command=java
 
 [program:druid-historical]
 user=druid
-command=java
+command=delay-start.sh 10 java
   -server
   -Xmx1g
   -Duser.timezone=UTC
@@ -81,7 +81,7 @@ priority=100
 
 [program:druid-broker]
 user=druid
-command=java
+command=delay-start.sh 10 java
   -server
   -Xmx1g
   -Duser.timezone=UTC


### PR DESCRIPTION
This is the source of instability after migrating to new jenkins slaves. Unfortunately supervisord isn't good at handling service dependencies (see https://github.com/Supervisor/supervisor/issues/122), so we hack it to add some extra sleep before starting druid services.

@loganlinn @jchen-opt @tylerbrandt 
