### PR TITLE
Add proper startup dependency from druid to mysql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,10 +71,6 @@ ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 # Add Yarn conf
 ADD yarn-conf /etc/hadoop/conf/
 
-# Druid overlord may be stuck in a bad state if mysql is not ready.
-# We'll delay the start of all druid services using this script.
-ADD delay-start.sh /usr/local/bin/
-
 # Expose ports:
 # - 8081: HTTP (coordinator)
 # - 8082: HTTP (broker)

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ WORKDIR /
 RUN /etc/init.d/mysql start && mysql -u root -e "GRANT ALL ON druid.* TO 'druid'@'localhost' IDENTIFIED BY 'diurd'; CREATE database druid CHARACTER SET utf8;" && /etc/init.d/mysql stop
 
 # Setup supervisord
-ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+ADD supervisord.conf /etc/supervisor/conf.d/druid.conf
 
 # Add Yarn conf
 ADD yarn-conf /etc/hadoop/conf/
@@ -86,4 +86,6 @@ EXPOSE 3306
 EXPOSE 2181 2888 3888
 
 WORKDIR /var/lib/druid
-ENTRYPOINT export HOSTIP="$(resolveip -s $HOSTNAME)" && exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
+ADD start.sh .
+
+ENTRYPOINT ["./start.sh"]

--- a/delay-start.sh
+++ b/delay-start.sh
@@ -1,5 +1,0 @@
-#!/bin/sh -e
-
-sleep $1
-shift
-exec "$@"

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+
+export HOSTIP="$(resolveip -s $HOSTNAME)"
+
+supervisord &
+
+# start druid services after mysql is ready, otherwise overlord may be stuck in a bad state
+while ! mysqladmin status > /dev/null 2>&1; do
+  echo "waiting for mysql to be ready ..."
+  sleep 1
+done
+
+supervisorctl start "druid:*"
+
+wait $!

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -12,7 +12,12 @@ command=/usr/bin/pidproxy /var/run/mysqld/mysqld.pid /usr/bin/mysqld_safe
 user=mysql
 priority=0
 
+[group:druid]
+programs=druid-coordinator,druid-indexing-service,druid-historical,druid-broker
+priority=100
+
 [program:druid-coordinator]
+autostart=false
 user=druid
 command=java
   -server
@@ -29,10 +34,9 @@ command=java
   -Ddruid.coordinator.startDelay=PT5S
   -cp /usr/local/druid/lib/*
   io.druid.cli.Main server coordinator
-redirect_stderr=true
-priority=100
 
 [program:druid-indexing-service]
+autostart=false
 user=druid
 command=java
   -server
@@ -58,6 +62,7 @@ command=java
   io.druid.cli.Main server overlord
 
 [program:druid-historical]
+autostart=false
 user=druid
 command=java
   -server
@@ -76,10 +81,9 @@ command=java
   -Ddruid.processing.numThreads=1
   -cp /usr/local/druid/lib/*:/etc/hadoop/conf
   io.druid.cli.Main server historical
-redirect_stderr=true
-priority=100
 
 [program:druid-broker]
+autostart=false
 user=druid
 command=java
   -server
@@ -93,5 +97,3 @@ command=java
   -Ddruid.processing.numThreads=1
   -cp /usr/local/druid/lib/*
   io.druid.cli.Main server broker
-redirect_stderr=true
-priority=100

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -14,7 +14,7 @@ priority=0
 
 [program:druid-coordinator]
 user=druid
-command=delay-start.sh 10 java
+command=java
   -server
   -Xmx1g
   -Duser.timezone=UTC
@@ -34,7 +34,7 @@ priority=100
 
 [program:druid-indexing-service]
 user=druid
-command=delay-start.sh 10 java
+command=java
   -server
   -Xmx256m
   -Duser.timezone=UTC
@@ -59,7 +59,7 @@ command=delay-start.sh 10 java
 
 [program:druid-historical]
 user=druid
-command=delay-start.sh 10 java
+command=java
   -server
   -Xmx1g
   -Duser.timezone=UTC
@@ -81,7 +81,7 @@ priority=100
 
 [program:druid-broker]
 user=druid
-command=delay-start.sh 10 java
+command=java
   -server
   -Xmx1g
   -Duser.timezone=UTC


### PR DESCRIPTION
Revert the delay-start hack which wasn't always reliable. Add proper startup dependency.

@loganlinn @jchen-opt @tylerbrandt 
